### PR TITLE
Feature: Custom Journal Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Users can access the "Journal" button via the actor's character sheet only if th
 - **Close Journal Page Editor on Save**: When enabled, the ProseMirror journal page editor will close automatically when saving changes.
 - **Allow Journal Page Sharing**: When enabled, the "Journal" button creates a single journal page in the "Actor Journal" for each actor. Deactivate this to if you want the "Journal" button to generate a unique page for each user. Other settings may allow other users to access these pages though.
 - **Set Default Ownership of "Actor Journal" Pages to "None"**: When enabled, the default ownership for the pages created with the "Journal" button is set to "None". Deactivate this to set it to "Owner". Automatic and manual ownership updates should be unnecessary with this deactivated as all users should be owners.
+- **Change Name of Default "Actor Journal" Page**: When the default value is changed, Actor Journal can use a custom name instead of "Actor Journal"
 - **Allow Automatic Journal Page Alphabetization with Socketlib**: When enabled, this automatically alphabetized journal pages in the "Actor Journal" by page name whenever a new pages is created using the "Journal" button. You may need to have Library - socketlib module activated depending on ownership configurations.
 - **Allow Automatic Journal Pages Ownership Updates with Socketlib**: When enabled, socketlib will automatically update ownership of journal pages in the "Actor Journal" when required. You must have Library - socketlib module activated for this to work.
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Users can access the "Journal" button via the actor's character sheet only if th
 - **Close Journal Page Editor on Save**: When enabled, the ProseMirror journal page editor will close automatically when saving changes.
 - **Allow Journal Page Sharing**: When enabled, the "Journal" button creates a single journal page in the "Actor Journal" for each actor. Deactivate this to if you want the "Journal" button to generate a unique page for each user. Other settings may allow other users to access these pages though.
 - **Set Default Ownership of "Actor Journal" Pages to "None"**: When enabled, the default ownership for the pages created with the "Journal" button is set to "None". Deactivate this to set it to "Owner". Automatic and manual ownership updates should be unnecessary with this deactivated as all users should be owners.
-- **Change Name of Default "Actor Journal" Page**: When the default value is changed, Actor Journal can use a custom name instead of "Actor Journal"
+- **Change Name of Default "Actor Journal" Page**: When the default value is changed, Actor Journal can use a custom name instead of "Actor Journal".
 - **Allow Automatic Journal Page Alphabetization with Socketlib**: When enabled, this automatically alphabetized journal pages in the "Actor Journal" by page name whenever a new pages is created using the "Journal" button. You may need to have Library - socketlib module activated depending on ownership configurations.
 - **Allow Automatic Journal Pages Ownership Updates with Socketlib**: When enabled, socketlib will automatically update ownership of journal pages in the "Actor Journal" when required. You must have Library - socketlib module activated for this to work.
 

--- a/module.json
+++ b/module.json
@@ -9,7 +9,7 @@
     "discord":"puddleimages"
     }
   ],
-  "version": "0.2.1",
+  "version": "0.3.0",
   "compatibility": {
     "minimum":"11",
     "verified": "11"

--- a/scripts/actor-journal-helper.js
+++ b/scripts/actor-journal-helper.js
@@ -111,8 +111,8 @@ async function alphabetizeActorJournalPages() {
 };
 
 Hooks.once('ready', async () => {
-  ensureActorJournalExists()
   getSettings()
+  ensureActorJournalExists()
 });
 
 let socket;

--- a/scripts/actor-journal-helper.js
+++ b/scripts/actor-journal-helper.js
@@ -62,6 +62,7 @@ Hooks.once('setup', () => {
     scope: "world",
     config: true,
     default: "Actor Journal",
+    requiresReload: true,
     type: String
   });
 });

--- a/scripts/actor-journal-helper.js
+++ b/scripts/actor-journal-helper.js
@@ -55,6 +55,15 @@ Hooks.once('setup', () => {
     default: false,
     type: Boolean
   });
+  
+  game.settings.register("actor-journal-helper", "actorJournalName", {
+    name: "Customize the name of the Actor Journal",
+    hint: 'When changed, Actor Journal will use a custom name instead of "Actor Journal". If changed after the original journal has been created, it will contribute to the newly named one instead.',
+    scope: "world",
+    config: true,
+    default: "Actor Journal",
+    type: String
+  });
 });
 
 let closeCharacterSheetOnJournalEditing;
@@ -63,6 +72,7 @@ let automaticAlphabetization;
 let defaultOwnershipSetting;
 let sharedJournalPages;
 let automaticOwnership;
+let actorJournalName;
 
 async function getSettings() {
   closeCharacterSheetOnJournalEditing = game.settings.get("actor-journal-helper", "closeCharacterSheetOnJournalEditing");
@@ -71,14 +81,15 @@ async function getSettings() {
   defaultOwnershipSetting = game.settings.get("actor-journal-helper", "defaultOwnership");
   sharedJournalPages = game.settings.get("actor-journal-helper", "sharedJournalPages");
   automaticOwnership = game.settings.get("actor-journal-helper", "automaticOwnership");
+  actorJournalName = game.settings.get("actor-journal-helper", "actorJournalName");
 };
 
 async function ensureActorJournalExists() {
-  const actorJournalEntry = game.journal.getName("Actor Journal");
+  const actorJournalEntry = game.journal.getName("actorJournalName");
   
   if (!actorJournalEntry) {
     await JournalEntry.create({
-      name: "Actor Journal",
+      name: actorJournalName,
       ownership: {
         default: 3,
       }
@@ -88,7 +99,7 @@ async function ensureActorJournalExists() {
 
 async function alphabetizeActorJournalPages() {
   try {
-    const actorJournalEntry = game.journal.getName("Actor Journal");
+    const actorJournalEntry = game.journal.getName(actorJournalName);
     const sortedPages = actorJournalEntry.pages
       .map(page => ({ _id: page.id, name: page.name }))
       .sort((a, b) => a.name.localeCompare(b.name))
@@ -162,7 +173,7 @@ Hooks.on('renderActorSheet', (app, html, data) => {
     };
 
     await ensureActorJournalExists()
-    const actorJournalEntry = await game.journal.getName("Actor Journal");
+    const actorJournalEntry = await game.journal.getName(actorJournalName);
 
     const actorJournalPageArray = await actorJournalEntry.pages.filter(page => {
       return page.getFlag('actor-journal-helper', 'actorId') === app.actor.id

--- a/scripts/actor-journal-helper.js
+++ b/scripts/actor-journal-helper.js
@@ -85,7 +85,7 @@ async function getSettings() {
 };
 
 async function ensureActorJournalExists() {
-  const actorJournalEntry = game.journal.getName("actorJournalName");
+  const actorJournalEntry = game.journal.getName(actorJournalName);
   
   if (!actorJournalEntry) {
     await JournalEntry.create({


### PR DESCRIPTION
Added a new setting for the "Actor Journal" name that is defaulted to "Actor Journal." Since the default is the exact same as the previously hard-coded name, it should not break existing user's setups. Implemented because I wanted to name my "Actor Journal" "Dramatis Personae" instead. Another use case is changing the naming every adventure/module to keep it uncluttered. A reload is required when changing the setting.